### PR TITLE
Fix test_metis_ConfigurationFile failure as root

### DIFF
--- a/ccnx/forwarder/metis/config/test/test_metis_ConfigurationFile.c
+++ b/ccnx/forwarder/metis/config/test/test_metis_ConfigurationFile.c
@@ -130,7 +130,12 @@ LONGBOW_TEST_CASE(Create, metisConfigurationFile_Create_CantRead)
     chmod(template, 0600);
     unlink(template);
 
-    assertNull(cf, "Should have returned null configuration file for non-readable file");
+    uid_t uid = getuid(), euid = geteuid();
+    if (uid <= 0 || uid != euid) {
+	metisConfigurationFile_Release(&cf);
+    } else {
+	assertNull(cf, "Should have returned null configuration file for non-readable file");
+    }
 
     metisForwarder_Destroy(&metis);
     close(fd);


### PR DESCRIPTION
* Running make check as sudo/root causes test: 60 - test_metis_ConfigurationFile to fail. 
* The reason behind it is that the test metisConfigurationFile_Create_CantRead does not apply to sudo/root which can read files even with "0" privileges.
* Solved by checking if the runner executing the tests has root privileges, in which case instead of calling the assertNull statement (which will fail), cf (not null) pointer is released.