### PR TITLE
Add support for "remove route" in Metis config/control

### DIFF
--- a/ccnx/forwarder/metis/config/metisControl_RemoveRoute.c
+++ b/ccnx/forwarder/metis/config/metisControl_RemoveRoute.c
@@ -64,6 +64,7 @@
 #include <strings.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <ctype.h>
 
 #include <LongBow/runtime.h>
 
@@ -92,18 +93,135 @@ metisControlRemoveRoute_HelpCreate(MetisControlState *state)
     return metisCommandOps_Create(state, _commandRemoveRouteHelp, NULL, _metisControlRemoveRoute_HelpExecute, metisCommandOps_Destroy);
 }
 
+/**
+ * Return true if string is purely an integer
+ */
+static bool
+_isNumber(const char *string)
+{
+    size_t len = strlen(string);
+    for (size_t i = 0; i < len; i++) {
+        if (!isdigit(string[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * A symbolic name must be at least 1 character and must begin with an alpha.
+ * The remainder must be an alphanum.
+ */
+static bool
+_validateSymbolicName(const char *symbolic)
+{
+    bool success = false;
+    size_t len = strlen(symbolic);
+    if (len > 0) {
+        if (isalpha(symbolic[0])) {
+            success = true;
+            for (size_t i = 1; i < len; i++) {
+                if (!isalnum(symbolic[i])) {
+                    success = false;
+                    break;
+                }
+            }
+        }
+    }
+    return success;
+}
+
 // ====================================================
 
 static MetisCommandReturn
 _metisControlRemoveRoute_HelpExecute(MetisCommandParser *parser, MetisCommandOps *ops, PARCList *args)
 {
-    printf("%s help not implemented (case 149)", ops->command);
+    printf("commands:\n");
+    printf("   remove route <symbolic | connid> <prefix>\n");
+    printf("\n");
+    printf("   symbolic:  The optional symbolic name for an exgress\n");
+    printf("   connid:    The optional egress connection id (see 'help list connections')\n");
+    printf("   prefix:    The CCNx name as a URI (e.g. lci:/foo/bar)\n");
+    printf("\n");
+    printf("Examples:\n");
+    printf("   remove route 25 lci:/foo/bar\n");
+    printf("      removes route to prefix '/foo/bar' on egress connection index 25\n");
+    printf("   remove route tun3 lci:/foo/bar\n");
+    printf("      removes route to prefix '/foo/bar' on egress connection 'tun3'\n");
+    printf("\n");
+    
     return MetisCommandReturn_Success;
 }
 
 static MetisCommandReturn
 _metisControlRemoveRoute_Execute(MetisCommandParser *parser, MetisCommandOps *ops, PARCList *args)
 {
-    printf("%s not implemented (case 149)", ops->command);
-    return MetisCommandReturn_Failure;
+    MetisControlState *state = ops->closure;
+
+    if (parcList_Size(args) != 4) {
+        _metisControlRemoveRoute_HelpExecute(parser, ops, args);
+        return MetisCommandReturn_Failure;
+    }
+
+    const char *symbolicOrConnid = parcList_GetAtIndex(args, 2);
+
+    if (_validateSymbolicName(symbolicOrConnid) || _isNumber(symbolicOrConnid)) {
+
+        const char *prefixString = parcList_GetAtIndex(args, 3);
+        CCNxName *prefix = ccnxName_CreateFromURI(prefixString);
+        if (prefix == NULL) {
+            printf("ERROR: could not parse prefix '%s'\n", prefixString);
+            return MetisCommandReturn_Failure;
+        }
+
+        char *protocolTypeAsString = "static";
+
+        CPINameRouteProtocolType protocolType = cpiNameRouteProtocolType_FromString(protocolTypeAsString);
+        CPINameRouteType routeType = cpiNameRouteType_LONGEST_MATCH;
+        CPIAddress *nexthop = NULL;
+
+        struct timeval *lifetime = NULL;
+
+        CPIRouteEntry *route = NULL;
+
+        if (_isNumber(symbolicOrConnid)) {
+            unsigned connid = (unsigned) strtold(symbolicOrConnid, NULL);
+            route = cpiRouteEntry_Create(prefix, connid, nexthop, protocolType, routeType, lifetime, 0);
+        } else {
+            route = cpiRouteEntry_CreateSymbolic(prefix, symbolicOrConnid, protocolType, routeType, lifetime, 0);
+        }
+
+        CCNxControl *addRouteRequest = ccnxControl_CreateRemoveRouteRequest(route);
+
+        cpiRouteEntry_Destroy(&route);
+
+        if (metisControlState_GetDebug(state)) {
+            char *str = parcJSON_ToString(ccnxControl_GetJson(addRouteRequest));
+            printf("request: %s\n", str);
+            parcMemory_Deallocate((void **) &str);
+        }
+
+        CCNxMetaMessage *message = ccnxMetaMessage_CreateFromControl(addRouteRequest);
+        CCNxMetaMessage *rawResponse = metisControlState_WriteRead(state, message);
+        ccnxMetaMessage_Release(&message);
+
+        ccnxControl_Release(&addRouteRequest);
+
+        CCNxControl *response = ccnxMetaMessage_GetControl(rawResponse);
+
+        if (metisControlState_GetDebug(state)) {
+            char *str = parcJSON_ToString(ccnxControl_GetJson(response));
+            printf("response: %s\n", str);
+            parcMemory_Deallocate((void **) &str);
+        }
+
+        ccnxMetaMessage_Release(&rawResponse);
+
+        return MetisCommandReturn_Success;
+    }
+    else {
+        printf("ERROR: Invalid symbolic or connid.  Symbolic name must begin with an alpha followed by alphanum.  connid must be an integer\n");
+        return MetisCommandReturn_Failure;
+    }
+
 }

--- a/ccnx/forwarder/metis/config/metisControl_RemoveRoute.c
+++ b/ccnx/forwarder/metis/config/metisControl_RemoveRoute.c
@@ -168,7 +168,7 @@ _metisControlRemoveRoute_Execute(MetisCommandParser *parser, MetisCommandOps *op
     if (_validateSymbolicName(symbolicOrConnid) || _isNumber(symbolicOrConnid)) {
 
         const char *prefixString = parcList_GetAtIndex(args, 3);
-        CCNxName *prefix = ccnxName_CreateFromURI(prefixString);
+        CCNxName *prefix = ccnxName_CreateFromCString(prefixString);
         if (prefix == NULL) {
             printf("ERROR: could not parse prefix '%s'\n", prefixString);
             return MetisCommandReturn_Failure;

--- a/documentation/manpage-source/metis.cfg.sgml
+++ b/documentation/manpage-source/metis.cfg.sgml
@@ -298,10 +298,10 @@ Done
 			</listitem>
 		</varlistentry>
 		<varlistentry>
-			<term>remove route</term>
+      <term>remove route <replaceable class="parameter">symbolic</replaceable> <replaceable class="parameter">prefix</replaceable></term>
 			<listitem>
 				<para>
-					Not implemented.
+					Removes a static route from the FIB.  The prefix and interface must match exactly for the route to be removed.
 				</para>
 			</listitem>
 		</varlistentry>

--- a/documentation/manpage/metis.cfg.5
+++ b/documentation/manpage/metis.cfg.5
@@ -142,8 +142,9 @@ Done
 .IP "remove connection" 10 
 Not implemented. 
  
-.IP "remove route" 10 
-Not implemented. 
+.IP "remove route \fIsymbolic\fR \fIprefix\fR" 10 
+Removes a static route from the FIB.  The prefix and interface must match exactly
+for the route to be removed.
  
 .SH "MISC COMMANDS" 
 .IP "quit" 10 

--- a/documentation/manpage/metis.cfg.5.html
+++ b/documentation/manpage/metis.cfg.5.html
@@ -334,9 +334,11 @@ connection</p>
 
 <p style="margin-left:26%;">Not implemented.</p>
 
-<p style="margin-left:11%;">remove route</p>
+<p style="margin-left:11%;">remove route <i>symbolic prefix</i></p>
 
-<p style="margin-left:26%;">Not implemented.</p>
+<p style="margin-left:26%;">Removes a static route from the FIB.
+ The prefix and interface must match exactly for the route to
+ be removed.</p>
 
 <h2>MISC COMMANDS
 <a name="MISC COMMANDS"></a>


### PR DESCRIPTION
Adds an implementation of the "remove route" command.  Arguments are:
- Interface (symbolic or index)
- Prefix

Both must match exactly in order for the route to be removed.  Documentation and some unit tests were also updated.

Note: PDF docs were not updated because I don't have an editor.
